### PR TITLE
docs(README.md): add missing npm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 * git clone https://github.com/belyanskii/bem-ide.git (клонируем)
 * cd bem-ide
+* npm i -g bem-cli
 * npm i
 * bem make
 * npm start (запускаем сервер на 7777 порту)


### PR DESCRIPTION
You couldn't run “bem make” command without global bem-cli module.
